### PR TITLE
Separate Pygments.rb and Rygments

### DIFF
--- a/lib/rack/codehighlighter.rb
+++ b/lib/rack/codehighlighter.rb
@@ -135,7 +135,18 @@ module Rack
       if refs
         lang = refs[1]
         str = unescape_html(string.sub(@opts[:pattern], ""))
-        #Pygments.highlight(str, :lexer => lang, :formatter => 'html')
+        options = @opts[:options]
+        Pygments.highlight(str, :lexer => lang, :formatter => 'html', :options => options)
+      else
+        "<pre>#{string}</pre>"
+      end
+    end
+
+    def rygments(string)
+      refs = @opts[:pattern].match(string)
+      if refs
+        lang = refs[1]
+        str = unescape_html(string.sub(@opts[:pattern], ""))
         Rygments.highlight_string(str, lang, 'html')
       else
         "<pre>#{string}</pre>"


### PR DESCRIPTION
I've separated Pygments.rb and Rygments—mostly for the fact that as far as I can tell, Rygments does not allow taking advantage of Pygments' full set of options (i.e. line numbers). I've added the ability to specify an `options` hash when using Pygments.rb that gets passed directly to Pygments, for example:

``` ruby
use Rack::Codehighlighter, :pygments, :markdown => true, :element => "pre>code", :pattern => /\A:::(\w+)\s*(\n|&#x000A;)/i, :logging => true, :options => { :linenos => 'table' }
```
