### PR TITLE
Support Transfer-Encoding with Phusion Passenger

### DIFF
--- a/lib/rack/codehighlighter.rb
+++ b/lib/rack/codehighlighter.rb
@@ -44,7 +44,8 @@ module Rack
         end
 
         body = doc.to_html
-        headers['content-length'] = bytesize(body).to_s
+
+        headers['Content-Length'] = bytesize(body).to_s
 
         log(env, status, headers, began_at) if @opts[:logging]
         [status, headers, [body]]


### PR DESCRIPTION
Passenger sets a Transfer-Encoding chunked header and only checks for the specific 'Content-Length' case to strip out a content length header. Although this could be said it’s a bug in passenger it’s also a symptom of using the Rack::Utils::HeaderHash which provides case insensitive readers but retain case sensitivity when assigning.

This causes nginx to return a 502 Bad Request error page and stops the application from functioning.