### PR TITLE
Make this work with Rack 2.0.0 / Rails 5.0.0.rc1

### DIFF
--- a/lib/rack/codehighlighter.rb
+++ b/lib/rack/codehighlighter.rb
@@ -45,7 +45,7 @@ module Rack
 
         body = doc.to_html
 
-        headers['Content-Length'] = bytesize(body).to_s
+        headers['Content-Length'] = body.bytesize.to_s
 
         log(env, status, headers, began_at) if @opts[:logging]
         [status, headers, [body]]


### PR DESCRIPTION
Rack 2.0.0 (required for Rails 5) removes the `Rack::Utils.bytesize` method, which is just `String#bytesize`
